### PR TITLE
Optional install and use journald by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,5 @@ jobs:
         run: pip3 install ansible-core
 
       - name: Trigger a new import on Galaxy.
-        run: "ansible-galaxy role import --api-key ${{ secrets.ANSIBLE_GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2) --branch main"
+        run: "ansible-galaxy role import \
+          --api-key ${{ secrets.ANSIBLE_GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2) --branch main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,7 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: "ansible-galaxy role import \
-          --api-key ${{ secrets.ANSIBLE_GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2) --branch main"
+          --api-key ${{ secrets.ANSIBLE_GALAXY_API_KEY }} \
+          $(echo ${{ github.repository }} | \
+          cut -d/ -f1) $(echo ${{ github.repository }} | \
+          cut -d/ -f2) --branch main"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ flower_python_path: ""
 flower_galaxy_conf: "{{ galaxy_root }}/config/galaxy.yml"
 
 flower_log_dir: /var/log/flower
+flower_log_num: 5
+flower_log_size: 20000000
 flower_conf_dir: /etc/flower
 
 flower_mem_limit: 2G

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,11 @@ flower_pip_version: python3-pip
 flower_user: galaxy
 flower_group: galaxy
 
+flower_venv_user: root
+flower_venv_group: root
+
+flower_install: true
+
 flower_app_dir: ""
 flower_app_name: ""
 flower_venv_dir: "/home/{{ flower_user }}/.local"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ flower_venv_dir: "/home/{{ flower_user }}/.local"
 flower_python_path: ""
 flower_galaxy_conf: "{{ galaxy_root }}/config/galaxy.yml"
 
-flower_log_file: /var/log/flower
+flower_log_dir: /var/log/flower
 flower_conf_dir: /etc/flower
 
 flower_mem_limit: 2G

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ flower_venv_dir: "/home/{{ flower_user }}/.local"
 flower_python_path: ""
 flower_galaxy_conf: "{{ galaxy_root }}/config/galaxy.yml"
 
+flower_custom_logging: false
 flower_log_dir: /var/log/flower
 flower_log_num: 5
 flower_log_size: 20000000

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ flower_bind_address: 0.0.0.0
 flower_port: 5555
 flower_broker_api: ""
 flower_persistent: "False"
-flower_db_file: "flower" # https://flower.readthedocs.io/en/latest/config.html#db
+flower_db_file: "flower"
 
 flower_broker_url: ""
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     owner: "{{ flower_user }}"
     group: "{{ flower_user }}"
     mode: 0755
+  when: flower_custom_logging
 
 - name: Ensure config directory exists
   tags: [flower, dirs]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,15 +39,6 @@
     group: root
     mode: 0755
 
-- name: Ensure Python3 and pip is installed
-  ansible.builtin.package:
-    name:
-      - "{{ flower_python_version }}"
-      - "{{ flower_pip_version }}"
-      - virtualenv
-    state: present
-  when: flower_install
-
 - name: Install virtualenv
   ansible.builtin.pip:
     name: virtualenv

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,19 +46,22 @@
       - "{{ flower_pip_version }}"
       - virtualenv
     state: present
+  when: flower_install
 
 - name: Install virtualenv
   ansible.builtin.pip:
     name: virtualenv
+  when: flower_install
 
 - name: Ensure venv directory exists
   tags: [flower, dirs]
   file:
     state: directory
     path: "{{ flower_venv_dir }}"
-    owner: root
-    group: root
+    owner: "{{ flower_venv_user }}"
+    group: "{{ flower_venv_group }}"
     mode: 0755
+  when: flower_install
 
 - name: Ensure Python Flower package is installed
   tags: [flower, python, pip]
@@ -68,6 +71,7 @@
     virtualenv: "{{ flower_venv_dir }}"
     virtualenv_python: "{{ flower_python_main }}"
     state: present
+  when: flower_install
 
 - name: Ensure Flower configuration file is correct
   tags: [flower, config]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,8 +24,8 @@
 - name: Ensure log directory exists
   tags: [flower, dirs]
   file:
-    state: touch
-    path: "{{ flower_log_file }}"
+    state: dir
+    path: "{{ flower_log_dir }}"
     owner: "{{ flower_user }}"
     group: "{{ flower_user }}"
     mode: 0755

--- a/templates/flower.service.j2
+++ b/templates/flower.service.j2
@@ -13,7 +13,7 @@ WorkingDirectory={{ flower_app_dir }}
 ExecStart={{ flower_venv_dir }}/bin/celery {% if flower_broker_url %}--broker={{ flower_broker_url }}{% endif %} \
   {% if flower_app_name %}-A {{ flower_app_name }}{% endif %} \
   flower {% if flower_conf_dir %}--conf={{ flower_conf_dir }}/flowerconfig.py{% endif %} \
-  {% if flower_log_file %}--log_file_prefix={{ flower_log_dir }}/flower.log {% endif %} \
+  {% if flower_log_dir %}--log_file_prefix={{ flower_log_dir }}/flower.log {% endif %} \
   {% if flower_log_num %}--log_file_num_backups={{ flower_log_num }} {% endif %} \
   {% if flower_log_size %}--log_file_max_size={{ flower_log_size }} {% endif %} \
   {% if flower_proxy_prefix is defined %}--url_prefix={{ flower_proxy_prefix }} {% endif %}

--- a/templates/flower.service.j2
+++ b/templates/flower.service.j2
@@ -13,7 +13,7 @@ WorkingDirectory={{ flower_app_dir }}
 ExecStart={{ flower_venv_dir }}/bin/celery {% if flower_broker_url %}--broker={{ flower_broker_url }}{% endif %} \
   {% if flower_app_name %}-A {{ flower_app_name }}{% endif %} \
   flower {% if flower_conf_dir %}--conf={{ flower_conf_dir }}/flowerconfig.py{% endif %} \
-  {% if flower_log_file %}--log_file_prefix={{ flower_log_file }} {% endif %} \
+  {% if flower_log_file %}--log_file_prefix={{ flower_log_dir }}/flower.log {% endif %} \
   {% if flower_log_num %}--log_file_num_backups={{ flower_log_num }} {% endif %} \
   {% if flower_log_size %}--log_file_max_size={{ flower_log_size }} {% endif %} \
   {% if flower_proxy_prefix is defined %}--url_prefix={{ flower_proxy_prefix }} {% endif %}

--- a/templates/flower.service.j2
+++ b/templates/flower.service.j2
@@ -10,7 +10,13 @@ User={{ flower_user }}
 Group={{ flower_group }}
 TimeoutStartSec=10
 WorkingDirectory={{ flower_app_dir }}
-ExecStart={{ flower_venv_dir }}/bin/celery {% if flower_broker_url %}--broker={{ flower_broker_url }}{% endif %} {% if flower_app_name %}-A {{ flower_app_name }}{% endif %} flower {% if flower_conf_dir %}--conf={{ flower_conf_dir }}/flowerconfig.py{% endif %} {% if flower_log_file %}--log_file_prefix={{ flower_log_file }} {% endif %} {% if flower_proxy_prefix is defined %}--url_prefix={{ flower_proxy_prefix }} {% endif %}
+ExecStart={{ flower_venv_dir }}/bin/celery {% if flower_broker_url %}--broker={{ flower_broker_url }}{% endif %} \
+  {% if flower_app_name %}-A {{ flower_app_name }}{% endif %} \
+  flower {% if flower_conf_dir %}--conf={{ flower_conf_dir }}/flowerconfig.py{% endif %} \
+  {% if flower_log_file %}--log_file_prefix={{ flower_log_file }} {% endif %} \
+  {% if flower_log_num %}--log_file_num_backups={{ flower_log_num }} {% endif %} \
+  {% if flower_log_size %}--log_file_max_size={{ flower_log_size }} {% endif %} \
+  {% if flower_proxy_prefix is defined %}--url_prefix={{ flower_proxy_prefix }} {% endif %}
 
 {% if flower_galaxy_conf %}Environment=GALAXY_CONFIG_FILE={{ flower_galaxy_conf }}{% endif %}
 

--- a/templates/flower.service.j2
+++ b/templates/flower.service.j2
@@ -13,9 +13,11 @@ WorkingDirectory={{ flower_app_dir }}
 ExecStart={{ flower_venv_dir }}/bin/celery {% if flower_broker_url %}--broker={{ flower_broker_url }}{% endif %} \
   {% if flower_app_name %}-A {{ flower_app_name }}{% endif %} \
   flower {% if flower_conf_dir %}--conf={{ flower_conf_dir }}/flowerconfig.py{% endif %} \
+  {% if flower_custom_logging %}
   {% if flower_log_dir %}--log_file_prefix={{ flower_log_dir }}/flower.log {% endif %} \
   {% if flower_log_num %}--log_file_num_backups={{ flower_log_num }} {% endif %} \
   {% if flower_log_size %}--log_file_max_size={{ flower_log_size }} {% endif %} \
+  {% endif %}
   {% if flower_proxy_prefix is defined %}--url_prefix={{ flower_proxy_prefix }} {% endif %}
 
 {% if flower_galaxy_conf %}Environment=GALAXY_CONFIG_FILE={{ flower_galaxy_conf }}{% endif %}


### PR DESCRIPTION
REMOVE: python, virtualenv and pip installing
ADD: variable that makes flower package installation optional
ADD: variable that makes venv owner configurable
ADD: variable that allows to enable custom logging settings (see #6 )
CHANGE: disable custom logging by default and use journald
Breaks:
- setups that rely on the python installation task
- setups that rely on custom logging and don't want to use journald

on top of
- #6 